### PR TITLE
update display for report_state function upon restore

### DIFF
--- a/curator/actions.py
+++ b/curator/actions.py
@@ -1939,7 +1939,7 @@ class Restore(object):
             for item in all_indices:
               if fnmatch.fnmatch(item, index):
                 found_count += 1
-                self.loggit.info('Found restored index {0}'.format(index))
+                self.loggit.info('Found restored index {0}'.format(item))
               else:
                 missing.append(index)
         if found_count >= len(self.expected_output):


### PR DESCRIPTION
When indices equals v2_audit_202*, 
report_state prints the following: 

2023-04-30 14:10:00,374 INFO      Found restored index v2_audit_202*
2023-04-30 14:10:00,374 INFO      Found restored index v2_audit_202*
2023-04-30 14:10:00,374 INFO      Found restored index v2_audit_202*
2023-04-30 14:10:00,374 INFO      Found restored index v2_audit_202*

instead of specific names like the following (for example)
2023-04-30 13:37:52,621 INFO      Found restored index v2_audit_2020
2023-04-30 13:37:52,621 INFO      Found restored index v2_audit_2021
2023-04-30 13:37:52,621 INFO      Found restored index v2_audit_2022
2023-04-30 13:37:52,621 INFO      Found restored index v2_audit_2023

My change fixes that 